### PR TITLE
Add feature for confirm and decline requests

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -111,7 +111,7 @@ class MakersBnB < Sinatra::Base
   end
 
   patch '/requests/:id' do
-    status = params.keys.include?('confirm') ? 'Confirmed' : 'Declined'
+    status = params.keys.include?('confirm') ? 'confirmed' : 'declined'
     Request.update(params[:id], status: status)
     redirect '/requests'
   end

--- a/app.rb
+++ b/app.rb
@@ -112,7 +112,17 @@ class MakersBnB < Sinatra::Base
 
   patch '/requests/:id' do
     status = params.keys.include?('confirm') ? 'confirmed' : 'declined'
-    Request.update(params[:id], status: status)
+    booking = Request.update(params[:id], status: status)
+
+    space_id = booking.space_id
+    date_requested = booking.date_requested
+
+    if params.keys.include?('confirm')
+      Request.all.each do |request|
+        request.update(status: 'declined') if request.space_id == space_id && request.date_requested == date_requested && request.id != booking.id
+      end
+    end
+
     redirect '/requests'
   end
 

--- a/app.rb
+++ b/app.rb
@@ -114,10 +114,9 @@ class MakersBnB < Sinatra::Base
     status = params.keys.include?('confirm') ? 'confirmed' : 'declined'
     booking = Request.update(params[:id], status: status)
 
-    space_id = booking.space_id
-    date_requested = booking.date_requested
-
-    if params.keys.include?('confirm')
+    if status == 'confirmed'
+      space_id = booking.space_id
+      date_requested = booking.date_requested
       Request.all.each do |request|
         request.update(status: 'declined') if request.space_id == space_id && request.date_requested == date_requested && request.id != booking.id
       end

--- a/spec/back_end/features/confirm_received_request_spec.rb
+++ b/spec/back_end/features/confirm_received_request_spec.rb
@@ -43,7 +43,7 @@ feature 'confirm received requests' do
     expect(page).not_to have_selector(:link_or_button, 'Decline request from: tuna@test.com')
   end
 
-  scenario 'after a user confirms a requests, all the others should be set as declined' do
+  scenario 'after a user confirms a requests, all the others with same date should be set as declined' do
     sign_up
     list_test_space
     click_on 'Sign out'

--- a/spec/back_end/features/confirm_received_request_spec.rb
+++ b/spec/back_end/features/confirm_received_request_spec.rb
@@ -42,4 +42,31 @@ feature 'confirm received requests' do
     expect(page).not_to have_selector(:link_or_button, 'Confirm request from: tuna@test.com')
     expect(page).not_to have_selector(:link_or_button, 'Decline request from: tuna@test.com')
   end
+
+  scenario 'after a user confirms a requests, all the others should be set as declined' do
+    sign_up
+    list_test_space
+    click_on 'Sign out'
+
+    sign_up_user_2
+    request_space
+    # log out (nav bar functionality to implement)
+
+    sign_up_user_3
+    request_space
+    # log out (nav bar functionality to implement)
+
+    sign_in
+    click_on 'Requests'
+    first('.request').click_button 'BIG HOUSE'
+    click_on 'Confirm request from: tuna@test.com'
+    # log out (nav bar functionality to implement)
+
+    sign_in_user_3
+    click_on 'Requests'
+
+    expect(page).to have_content 'BIG HOUSE'
+    expect(page).to have_content '12122020'
+    expect(page).to have_content 'declined'
+  end
 end

--- a/spec/back_end/features/confirm_received_request_spec.rb
+++ b/spec/back_end/features/confirm_received_request_spec.rb
@@ -1,5 +1,5 @@
 feature 'confirm received requests' do
-  scenario 'a user can confirm received requests' do
+  scenario 'a user can confirm a received request' do
     sign_up
     list_test_space
     click_on 'Sign out'
@@ -20,6 +20,26 @@ feature 'confirm received requests' do
     click_on 'Confirm request from: tuna@test.com'
 
     expect(page).to have_current_path '/requests'
-    expect(page).to have_content 'Confirmed'
-  end 
+    expect(page).to have_content 'confirmed'
+  end
+
+  scenario 'a user cannot re-confirm an already received request' do
+    sign_up
+    list_test_space
+    click_on 'Sign out'
+
+    sign_up_user_2
+    request_space
+    # log out (nav bar functionality to implement)
+
+    sign_in
+    click_on 'Requests'
+    click_on 'BIG HOUSE'
+    click_on 'Confirm request from: tuna@test.com'
+    click_on 'BIG HOUSE'
+
+    expect(page).to have_content 'Booking confirmed'
+    expect(page).not_to have_selector(:link_or_button, 'Confirm request from: tuna@test.com')
+    expect(page).not_to have_selector(:link_or_button, 'Decline request from: tuna@test.com')
+  end
 end

--- a/spec/back_end/features/decline_received_request_spec.rb
+++ b/spec/back_end/features/decline_received_request_spec.rb
@@ -1,5 +1,5 @@
 feature 'decline received requests' do
-  scenario 'a user can decline received requests' do
+  scenario 'a user can decline a received request' do
     sign_up
     list_test_space
     click_on 'Sign out'
@@ -20,6 +20,26 @@ feature 'decline received requests' do
     click_on 'Decline request from: tuna@test.com'
 
     expect(page).to have_current_path '/requests'
-    expect(page).to have_content 'Declined'
+    expect(page).to have_content 'declined'
+  end
+
+  scenario 'a user cannot decline an already declined request' do
+    sign_up
+    list_test_space
+    click_on 'Sign out'
+
+    sign_up_user_2
+    request_space
+    # log out (nav bar functionality to implement)
+
+    sign_in
+    click_on 'Requests'
+    click_on 'BIG HOUSE'
+    click_on 'Decline request from: tuna@test.com'
+    click_on 'BIG HOUSE'
+
+    expect(page).to have_content 'Booking declined'
+    expect(page).not_to have_selector(:link_or_button, 'Confirm request from: tuna@test.com')
+    expect(page).not_to have_selector(:link_or_button, 'Decline request from: tuna@test.com')
   end 
 end

--- a/spec/back_end/features/web_helpers.rb
+++ b/spec/back_end/features/web_helpers.rb
@@ -14,6 +14,30 @@ def sign_in
   click_on 'Log in'
 end
 
+def sign_up_user_2
+  visit '/'
+  fill_in 'email address', with: 'tuna@test.com'
+  fill_in 'password', with: '12345'
+  fill_in 'password confirmation', with: '12345'
+  click_on 'Sign up'
+end
+
+def sign_up_user_3
+  visit '/'
+  fill_in 'email address', with: 'sam@test.com'
+  fill_in 'password', with: '12345'
+  fill_in 'password confirmation', with: '12345'
+  click_on 'Sign up'
+end
+
+def sign_in_user_3
+  visit '/'
+  click_on 'Login'
+  fill_in 'Email Address', with: 'sam@test.com'
+  fill_in 'Password', with: '12345'
+  click_on 'Log in'
+end
+
 def one_week
   604800 # in seconds
 end
@@ -42,14 +66,6 @@ end
 
 def test_space
   Space.where(name: 'BIG HOUSE').first
-end
-
-def sign_up_user_2
-  visit '/'
-  fill_in 'email address', with: 'tuna@test.com'
-  fill_in 'password', with: '12345'
-  fill_in 'password confirmation', with: '12345'
-  click_on 'Sign up'
 end
 
 def request_space

--- a/views/requests/profile.erb
+++ b/views/requests/profile.erb
@@ -12,8 +12,12 @@
 
     <form action='/requests/<%= @booking.id %>' method='POST'>
       <input type='hidden' name='_method' value='PATCH'>
-      <input type='submit' name='confirm' value='Confirm request from: <%= @user_from.email %>'>
-      <input type='submit' name='decline' value='Decline request from: <%= @user_from.email %>'>
+      <% if ['confirmed', 'declined'].include? @booking.status %>
+        <p>Booking <%= @booking.status %></p>
+      <% else %>
+        <input type='submit' name='confirm' value='Confirm request from: <%= @user_from.email %>'>
+        <input type='submit' name='decline' value='Decline request from: <%= @user_from.email %>'>
+      <% end %>
     </form>
   </body>
 </html>


### PR DESCRIPTION
- Remove buttons from request page after it has been confirmed or declined
- Add feature to show declined for requests with the same date, after a confirmed booking has been made